### PR TITLE
Ignore comment lines

### DIFF
--- a/configparser.go
+++ b/configparser.go
@@ -16,6 +16,7 @@ import (
 // see python3 configparser.py
 var sectionRE = regexp.MustCompile(`\[(?P<header>[^]]+)\]`)
 var optionRE = regexp.MustCompile(`^(?P<option>.*?)\s*(?P<vi>[=|:])\s*(?P<value>.*)$`)
+var commentRE = regexp.MustCompile(`^\s*[#;].*$`)
 
 var booleanStates = map[string]bool{
 	"1": true, "yes": true, "true": true, "on": true,
@@ -104,7 +105,7 @@ func (c *ConfigParser) Read(r io.Reader) (err error) {
 
 	curSect := ""
 	// we allow files with no [section] header in this mode, by
-	// default its a error to be alinged with what python configparser
+	// default its a error to be aligned with what python configparser
 	// is doing
 	if c.AllowNoSectionHeader {
 		c.sections[""] = Section{
@@ -112,7 +113,9 @@ func (c *ConfigParser) Read(r io.Reader) (err error) {
 	}
 	for scanner.Scan() {
 		line := scanner.Text()
-		if sectionRE.MatchString(line) {
+		if commentRE.MatchString(line) {
+			// Do nothing
+		} else if sectionRE.MatchString(line) {
 			matches := sectionRE.FindStringSubmatch(line)
 			curSect = matches[1]
 			c.sections[curSect] = Section{

--- a/configparser_test.go
+++ b/configparser_test.go
@@ -20,6 +20,9 @@ type ConfigParserTestSuite struct {
 var _ = Suite(&ConfigParserTestSuite{})
 
 const SAMPLE_INI = `
+# comment: text
+  ; indented_comment: text
+
 [service]
 base: system-image.ubuntu.com
 http_port: 80


### PR DESCRIPTION
Currently there's a bug where a comment line including a colon matches
as an option, breaking the parser. The Python spec says that a comment
starts with a "#" or ";" and can be preceded by whitespace, so
`^\s*[#;].*$` seems like a suitable regex.

https://docs.python.org/3/library/configparser.html#supported-ini-file-structure