### PR TITLE
Add option setting and configuration write

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Canonical
+Copyright (c) 2014,2019 Canonical
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Current Limitations:
 --------------------
  * no interpolation
  * no defaults
- * no write support
  * not all API is provided
 
 [travis-image]: https://travis-ci.org/mvo5/goconfigparser.svg?branch=master


### PR DESCRIPTION
Add a number of functions from the original API, such as `AddSection`,
`HasSection`, `HasOption`, `Set`, `Write`, `RemoveOption` and
`RemoveSection`.

Note: there are intentional differences in this implementation compared
to the original Python API: `RemoveOption` and `RemoveSection` return an
error to be more idiomatic and consistent with other Go calls, and the
additional convenience function `WriteFile` was added.

Signed-off-by: Claudio Matsuoka <cmatsuoka@gmail.com>